### PR TITLE
fix: align flow manifest schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lasso-totaljs-flow
 
-Service Lasso package repo for the TypeRefinery Total.js Flow donor app.
+Service Lasso package repo for the Total.js Flow app.
 
 The release pipeline packages the app with production `npm` dependencies already installed, publishes OS-specific archives, and publishes the matching `service.json` manifest.
 

--- a/scripts/package.mjs
+++ b/scripts/package.mjs
@@ -84,8 +84,7 @@ export async function packageFlow(platform = targetPlatform, version = serviceVe
       {
         serviceId: "totaljs-flow",
         upstream: {
-          source: "TypeRefinery donor service",
-          donorPath: "services/totaljs-flow",
+          source: "Total.js Flow",
           version,
         },
         packagedBy: "service-lasso/lasso-totaljs-flow",

--- a/scripts/verify.mjs
+++ b/scripts/verify.mjs
@@ -1,6 +1,6 @@
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, readFile, rm } from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,6 +11,22 @@ const serviceVersion = process.env.TOTALJS_FLOW_VERSION ?? "10.0.0";
 const targetPlatform = process.env.TARGET_PLATFORM ?? process.platform;
 const verifyPort = Number(process.env.VERIFY_PORT ?? 18111);
 const messagePort = Number(process.env.VERIFY_MESSAGE_PORT ?? 18112);
+
+const serviceManifest = JSON.parse(await readFile(path.join(repoRoot, "service.json"), "utf8"));
+if (
+  serviceManifest.id !== "totaljs-flow" ||
+  serviceManifest.execservice !== "@node" ||
+  serviceManifest.artifact?.kind !== "archive" ||
+  serviceManifest.artifact.platforms?.[targetPlatform]?.assetName !== archiveName(targetPlatform) ||
+  serviceManifest.artifact.platforms?.[targetPlatform]?.archiveType !== (targetPlatform === "win32" ? "zip" : "tar.gz") ||
+  serviceManifest.ports?.service !== 8111 ||
+  serviceManifest.healthcheck?.type !== "http" ||
+  serviceManifest.healthcheck?.expected_status !== 200 ||
+  !serviceManifest.depend_on?.includes("@node") ||
+  !serviceManifest.depend_on?.includes("totaljs-messageservice")
+) {
+  throw new Error(`Total.js Flow manifest drifted from current Service Lasso schema: ${JSON.stringify(serviceManifest)}`);
+}
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {

--- a/service.json
+++ b/service.json
@@ -5,10 +5,30 @@
   "description": "Total.js Flow server packaged for Service Lasso.",
   "version": "10.0.0",
   "enabled": true,
-  "status": "30",
-  "icon": "pi pi-globe",
-  "servicelocation": 10,
+  "execservice": "@node",
+  "ports": {
+    "service": 8111
+  },
+  "env": {
+    "NODE_ENV": "production",
+    "FLOW_PORT": "${SERVICE_PORT}",
+    "FLOW_HOST_URL": "http://127.0.0.1:${SERVICE_PORT}",
+    "MESSAGESERVICE_PORT": "${MESSAGESERVICE_PORT}",
+    "MESSAGESERVICE_URL": "${MESSAGESERVICE_URL}"
+  },
+  "globalenv": {
+    "FLOW_HOST_URL": "${FLOW_HOST_URL}",
+    "FLOW_PORT": "${FLOW_PORT}"
+  },
+  "urls": [
+    {
+      "label": "Total.js Flow",
+      "url": "${FLOW_HOST_URL}/",
+      "kind": "local"
+    }
+  ],
   "artifact": {
+    "kind": "archive",
     "source": {
       "type": "github-release",
       "repo": "service-lasso/lasso-totaljs-flow",
@@ -16,62 +36,43 @@
     },
     "platforms": {
       "win32": {
-        "asset": "lasso-totaljs-flow-10.0.0-win32.zip",
-        "archive": "zip",
+        "assetName": "lasso-totaljs-flow-10.0.0-win32.zip",
+        "archiveType": "zip",
         "command": "./lasso-totaljs-flow.mjs"
       },
       "linux": {
-        "asset": "lasso-totaljs-flow-10.0.0-linux.tar.gz",
-        "archive": "tar.gz",
+        "assetName": "lasso-totaljs-flow-10.0.0-linux.tar.gz",
+        "archiveType": "tar.gz",
         "command": "./lasso-totaljs-flow.mjs"
       },
       "darwin": {
-        "asset": "lasso-totaljs-flow-10.0.0-darwin.tar.gz",
-        "archive": "tar.gz",
+        "assetName": "lasso-totaljs-flow-10.0.0-darwin.tar.gz",
+        "archiveType": "tar.gz",
         "command": "./lasso-totaljs-flow.mjs"
       }
     }
   },
-  "execconfig": {
-    "debuglog": true,
-    "execservice": {
-      "id": "@node"
-    },
-    "datapath": "./database",
-    "commandline": {
-      "win32": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-flow.mjs",
-      "linux": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-flow.mjs",
-      "darwin": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-flow.mjs",
-      "default": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-flow.mjs"
-    },
-    "env": {
-      "NODE_ENV": "production",
-      "FLOW_PORT": "${SERVICE_PORT}",
-      "FLOW_HOST_URL": "http://127.0.0.1:${SERVICE_PORT}"
-    },
-    "globalenv": {
-      "FLOW_HOST_URL": "http://127.0.0.1:${SERVICE_PORT}",
-      "FLOW_PORT": "${SERVICE_PORT}"
-    },
-    "serviceport": 8111,
-    "healthcheck": {
-      "type": "http",
-      "url": "http://127.0.0.1:${SERVICE_PORT}/",
-      "expected_status": 200,
-      "retries": 180,
-      "interval_ms": 500
-    },
-    "depend_on": [
-      "@node",
-      "totaljs-messageservice"
-    ]
+  "commandline": {
+    "win32": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-flow.mjs",
+    "linux": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-flow.mjs",
+    "darwin": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-flow.mjs",
+    "default": "${SERVICE_ARTIFACT_ROOT}/lasso-totaljs-flow.mjs"
   },
+  "healthcheck": {
+    "type": "http",
+    "url": "http://127.0.0.1:${SERVICE_PORT}/",
+    "expected_status": 200,
+    "retries": 180,
+    "interval": 500
+  },
+  "depend_on": [
+    "@node",
+    "totaljs-messageservice"
+  ],
   "updates": {
-    "policy": "notify",
-    "source": {
-      "type": "github-release",
-      "repo": "service-lasso/lasso-totaljs-flow",
-      "channel": "latest"
-    }
+    "enabled": true,
+    "mode": "notify",
+    "track": "latest",
+    "checkIntervalSeconds": 86400
   }
 }


### PR DESCRIPTION
Closes #2.

## Change
- Rewrites `service.json` to the current Service Lasso manifest shape with `artifact.kind`, `assetName`, `archiveType`, top-level `execservice`, `ports`, `env`, `globalenv`, `commandline`, `healthcheck`, and `depend_on`.
- Keeps Flow dependent on `totaljs-messageservice` and exporting `FLOW_HOST_URL` / `FLOW_PORT`.
- Updates verifier guardrails so schema drift is caught locally.
- Removes leftover donor wording from README/package metadata.

## Verification
- `npm test`
  - packages the current OS archive
  - extracts it
  - starts the packaged wrapper with message-service env values
  - verifies HTTP `/` returns expected `200`
- `node --check scripts/package.mjs scripts/verify.mjs`
- `git diff --check`

## Residual Risk
- Existing inherited Total.js Flow npm audit findings are still printed during package install. They are not changed by this schema-compatibility fix.

## Related
- Unblocks service-lasso/lasso-websight-cms#2 live-stack validation.